### PR TITLE
Add damage adjustment option

### DIFF
--- a/Masterplan/Data/CampaignSettings.cs
+++ b/Masterplan/Data/CampaignSettings.cs
@@ -43,7 +43,7 @@ namespace Masterplan.Data
 		/// </summary>
 		public double Damage
 		{
-			get { return fDamage; }
+			get { if (fDamage == 0) fDamage = 1; return fDamage; }
 			set { if (value == 0) value = 1; fDamage = value; }
 		}
 		double fDamage = 1.0;

--- a/Masterplan/Data/CampaignSettings.cs
+++ b/Masterplan/Data/CampaignSettings.cs
@@ -39,6 +39,16 @@ namespace Masterplan.Data
 		int fAttackBonus = 0;
 
 		/// <summary>
+		/// Gets or sets the damage multiplier.
+		/// </summary>
+		public double Damage
+		{
+			get { return fDamage; }
+			set { if (value == 0) value = 1; fDamage = value; }
+		}
+		double fDamage = 1.0;
+
+		/// <summary>
 		/// Gets or sets the bonus to AC.
 		/// </summary>
 		public int ACBonus

--- a/Masterplan/Data/EncounterCard.cs
+++ b/Masterplan/Data/EncounterCard.cs
@@ -853,7 +853,7 @@ namespace Masterplan.Data
                 }
 
 				// Handle level adjustment
-				if (fLevelAdjustment != 0)
+				if (fLevelAdjustment != 0 || Session.Project.CampaignSettings.AttackBonus!=0 || Math.Abs(Session.Project.CampaignSettings.Damage-1.0)< 1e-5)
 				{
 					foreach (CreaturePower cp in powers)
 					{
@@ -876,9 +876,10 @@ namespace Masterplan.Data
 							if (exp != null)
 							{
 								DiceExpression exp_adj = exp.Adjust(fLevelAdjustment);
-								if ((exp_adj != null) && (exp.ToString() != exp_adj.ToString()))
+								DiceExpression exp_adj_2 = exp_adj.Adjust(Session.Project.CampaignSettings.Damage);
+								if ((exp_adj_2 != null) && (exp.ToString() != exp_adj_2.ToString()))
 								{
-									cp.Details = cp.Details.Replace(dmg_str, exp_adj + " damage (adjusted from " + dmg_str + ")");
+									cp.Details = cp.Details.Replace(dmg_str, exp_adj_2 + " damage (adjusted from " + dmg_str + ")");
 								}
 							}
 						}

--- a/Masterplan/Data/EncounterCard.cs
+++ b/Masterplan/Data/EncounterCard.cs
@@ -853,7 +853,7 @@ namespace Masterplan.Data
                 }
 
 				// Handle level adjustment
-				if (fLevelAdjustment != 0 || Session.Project.CampaignSettings.AttackBonus!=0 || Math.Abs(Session.Project.CampaignSettings.Damage-1.0)< 1e-5)
+				if (fLevelAdjustment != 0 || Session.Project.CampaignSettings.AttackBonus != 0 || Math.Abs(Session.Project.CampaignSettings.Damage - 1.0) < 1e-5)
 				{
 					foreach (CreaturePower cp in powers)
 					{

--- a/Masterplan/Data/EncounterCard.cs
+++ b/Masterplan/Data/EncounterCard.cs
@@ -876,10 +876,22 @@ namespace Masterplan.Data
 							if (exp != null)
 							{
 								DiceExpression exp_adj = exp.Adjust(fLevelAdjustment);
-								DiceExpression exp_adj_2 = exp_adj.Adjust(Session.Project.CampaignSettings.Damage);
-								if ((exp_adj_2 != null) && (exp.ToString() != exp_adj_2.ToString()))
+								if ((exp_adj != null) && (exp.ToString() != exp_adj.ToString()))
 								{
-									cp.Details = cp.Details.Replace(dmg_str, exp_adj_2 + " damage (adjusted from " + dmg_str + ")");
+									cp.Details = cp.Details.Replace(dmg_str, exp_adj + " damage (adjusted from " + dmg_str + ")");
+								}
+							}
+						}
+						string dmg_str_2 = AI.ExtractDamageR(cp.Details);
+						if (dmg_str_2 !="")
+                        {
+							DiceExpression exp = DiceExpression.Parse(dmg_str_2);
+							if (exp != null)
+							{
+								DiceExpression exp_adj = exp.Adjust(Session.Project.CampaignSettings.Damage);
+								if ((exp_adj != null) && (exp.ToString() != exp_adj.ToString()))
+								{
+									cp.Details = cp.Details.Replace(dmg_str_2, exp_adj + " (was " + dmg_str_2 +")");
 								}
 							}
 						}

--- a/Masterplan/Tools/AI.cs
+++ b/Masterplan/Tools/AI.cs
@@ -1,7 +1,7 @@
 ﻿using System;
+using System.Text.RegularExpressions;
 
 using Masterplan.Data;
-using System.Text.RegularExpressions;
 
 namespace Masterplan.Tools
 {

--- a/Masterplan/Tools/AI.cs
+++ b/Masterplan/Tools/AI.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 
 using Masterplan.Data;
+using System.Text.RegularExpressions;
 
 namespace Masterplan.Tools
 {
@@ -282,6 +283,30 @@ namespace Masterplan.Tools
 					return section;
 			}
 
+			return "";
+		}
+
+		const String damageRegExp = @"((?<dCount>[0-9]{1,2})d(?<dSize>[0-9]{1,2})[ ]*(?<dConst>(\+|-)[ ]*[0-9]{1,2})?|(?<dConst>[0-9]{1,2}))[ ]*[a-z, ]*?[ ]+(dmg|damage)";
+		/*
+		 * This regexp will match text like 
+		 * 10d12+3 fire and lightning damage
+		 * 12 fire dmg
+		 * 1d6 - 3 damage
+		 * 
+		 * it has 3 named capture groups - 
+		 * dCount contains the number of dice to roll
+		 * dSize has the sides on the dice to roll
+		 * dConst has the constant damage expression
+		 */
+
+		public static string ExtractDamageR(string source)
+		{
+			Regex re = new Regex(damageRegExp);
+			Match match = re.Match(source);
+			if (match.Success)
+            {
+				return match.Value;
+            }
 			return "";
 		}
 

--- a/Masterplan/Tools/Dice.cs
+++ b/Masterplan/Tools/Dice.cs
@@ -385,5 +385,14 @@ namespace Masterplan.Tools
 
 			return adjusted;
 		}
+		public DiceExpression Adjust(double percentage_adjustment)
+		{
+			double diceExpected = Throws * (Sides + 1) / 2.0f;
+			double expected = diceExpected + Constant;
+			double adjusted = expected * percentage_adjustment;
+			double adjustedConstant = adjusted - diceExpected;
+
+			return new DiceExpression(Throws, Sides, (int)adjustedConstant);
+		}
 	}
 }

--- a/Masterplan/UI/CampaignSettingsForm.Designer.cs
+++ b/Masterplan/UI/CampaignSettingsForm.Designer.cs
@@ -28,220 +28,254 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.OKBtn = new System.Windows.Forms.Button();
-			this.CancelBtn = new System.Windows.Forms.Button();
-			this.HPLbl = new System.Windows.Forms.Label();
-			this.HPBox = new System.Windows.Forms.NumericUpDown();
-			this.AttackBox = new System.Windows.Forms.NumericUpDown();
-			this.AttackLbl = new System.Windows.Forms.Label();
-			this.ACBox = new System.Windows.Forms.NumericUpDown();
-			this.ACLbl = new System.Windows.Forms.Label();
-			this.InfoLbl = new System.Windows.Forms.Label();
-			this.DefenceBox = new System.Windows.Forms.NumericUpDown();
-			this.DefenceLbl = new System.Windows.Forms.Label();
-			this.XPBox = new System.Windows.Forms.NumericUpDown();
-			this.XPLbl = new System.Windows.Forms.Label();
-			((System.ComponentModel.ISupportInitialize)(this.HPBox)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.AttackBox)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.ACBox)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.DefenceBox)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.XPBox)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// OKBtn
-			// 
-			this.OKBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.OKBtn.DialogResult = System.Windows.Forms.DialogResult.OK;
-			this.OKBtn.Location = new System.Drawing.Point(110, 231);
-			this.OKBtn.Name = "OKBtn";
-			this.OKBtn.Size = new System.Drawing.Size(75, 23);
-			this.OKBtn.TabIndex = 11;
-			this.OKBtn.Text = "OK";
-			this.OKBtn.UseVisualStyleBackColor = true;
-			this.OKBtn.Click += new System.EventHandler(this.OKBtn_Click);
-			// 
-			// CancelBtn
-			// 
-			this.CancelBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.CancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.CancelBtn.Location = new System.Drawing.Point(191, 231);
-			this.CancelBtn.Name = "CancelBtn";
-			this.CancelBtn.Size = new System.Drawing.Size(75, 23);
-			this.CancelBtn.TabIndex = 12;
-			this.CancelBtn.Text = "Cancel";
-			this.CancelBtn.UseVisualStyleBackColor = true;
-			// 
-			// HPLbl
-			// 
-			this.HPLbl.AutoSize = true;
-			this.HPLbl.Location = new System.Drawing.Point(12, 55);
-			this.HPLbl.Name = "HPLbl";
-			this.HPLbl.Size = new System.Drawing.Size(72, 13);
-			this.HPLbl.TabIndex = 1;
-			this.HPLbl.Text = "Hit Points (%):";
-			// 
-			// HPBox
-			// 
-			this.HPBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.HPBox.Increment = new decimal(new int[] {
+            this.OKBtn = new System.Windows.Forms.Button();
+            this.CancelBtn = new System.Windows.Forms.Button();
+            this.HPLbl = new System.Windows.Forms.Label();
+            this.HPBox = new System.Windows.Forms.NumericUpDown();
+            this.AttackBox = new System.Windows.Forms.NumericUpDown();
+            this.AttackLbl = new System.Windows.Forms.Label();
+            this.ACBox = new System.Windows.Forms.NumericUpDown();
+            this.ACLbl = new System.Windows.Forms.Label();
+            this.InfoLbl = new System.Windows.Forms.Label();
+            this.DefenceBox = new System.Windows.Forms.NumericUpDown();
+            this.DefenceLbl = new System.Windows.Forms.Label();
+            this.XPBox = new System.Windows.Forms.NumericUpDown();
+            this.XPLbl = new System.Windows.Forms.Label();
+            this.DamageBox = new System.Windows.Forms.NumericUpDown();
+            this.dmgMultLbl = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.HPBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.AttackBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ACBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DefenceBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.XPBox)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DamageBox)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // OKBtn
+            // 
+            this.OKBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.OKBtn.DialogResult = System.Windows.Forms.DialogResult.OK;
+            this.OKBtn.Location = new System.Drawing.Point(110, 256);
+            this.OKBtn.Name = "OKBtn";
+            this.OKBtn.Size = new System.Drawing.Size(75, 23);
+            this.OKBtn.TabIndex = 11;
+            this.OKBtn.Text = "OK";
+            this.OKBtn.UseVisualStyleBackColor = true;
+            this.OKBtn.Click += new System.EventHandler(this.OKBtn_Click);
+            // 
+            // CancelBtn
+            // 
+            this.CancelBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.CancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.CancelBtn.Location = new System.Drawing.Point(191, 256);
+            this.CancelBtn.Name = "CancelBtn";
+            this.CancelBtn.Size = new System.Drawing.Size(75, 23);
+            this.CancelBtn.TabIndex = 12;
+            this.CancelBtn.Text = "Cancel";
+            this.CancelBtn.UseVisualStyleBackColor = true;
+            // 
+            // HPLbl
+            // 
+            this.HPLbl.AutoSize = true;
+            this.HPLbl.Location = new System.Drawing.Point(12, 55);
+            this.HPLbl.Name = "HPLbl";
+            this.HPLbl.Size = new System.Drawing.Size(72, 13);
+            this.HPLbl.TabIndex = 1;
+            this.HPLbl.Text = "Hit Points (%):";
+            // 
+            // HPBox
+            // 
+            this.HPBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.HPBox.Increment = new decimal(new int[] {
             5,
             0,
             0,
             0});
-			this.HPBox.Location = new System.Drawing.Point(130, 53);
-			this.HPBox.Maximum = new decimal(new int[] {
+            this.HPBox.Location = new System.Drawing.Point(130, 53);
+            this.HPBox.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
-			this.HPBox.Name = "HPBox";
-			this.HPBox.Size = new System.Drawing.Size(136, 20);
-			this.HPBox.TabIndex = 2;
-			// 
-			// AttackBox
-			// 
-			this.AttackBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.AttackBox.Location = new System.Drawing.Point(130, 121);
-			this.AttackBox.Minimum = new decimal(new int[] {
+            this.HPBox.Name = "HPBox";
+            this.HPBox.Size = new System.Drawing.Size(136, 20);
+            this.HPBox.TabIndex = 2;
+            // 
+            // AttackBox
+            // 
+            this.AttackBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.AttackBox.Location = new System.Drawing.Point(130, 121);
+            this.AttackBox.Minimum = new decimal(new int[] {
             100,
             0,
             0,
             -2147483648});
-			this.AttackBox.Name = "AttackBox";
-			this.AttackBox.Size = new System.Drawing.Size(136, 20);
-			this.AttackBox.TabIndex = 6;
-			// 
-			// AttackLbl
-			// 
-			this.AttackLbl.AutoSize = true;
-			this.AttackLbl.Location = new System.Drawing.Point(12, 123);
-			this.AttackLbl.Name = "AttackLbl";
-			this.AttackLbl.Size = new System.Drawing.Size(74, 13);
-			this.AttackLbl.TabIndex = 5;
-			this.AttackLbl.Text = "Attack Bonus:";
-			// 
-			// ACBox
-			// 
-			this.ACBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.ACBox.Location = new System.Drawing.Point(130, 163);
-			this.ACBox.Minimum = new decimal(new int[] {
+            this.AttackBox.Name = "AttackBox";
+            this.AttackBox.Size = new System.Drawing.Size(136, 20);
+            this.AttackBox.TabIndex = 6;
+            // 
+            // AttackLbl
+            // 
+            this.AttackLbl.AutoSize = true;
+            this.AttackLbl.Location = new System.Drawing.Point(12, 123);
+            this.AttackLbl.Name = "AttackLbl";
+            this.AttackLbl.Size = new System.Drawing.Size(74, 13);
+            this.AttackLbl.TabIndex = 5;
+            this.AttackLbl.Text = "Attack Bonus:";
+            // 
+            // ACBox
+            // 
+            this.ACBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.ACBox.Location = new System.Drawing.Point(130, 183);
+            this.ACBox.Minimum = new decimal(new int[] {
             100,
             0,
             0,
             -2147483648});
-			this.ACBox.Name = "ACBox";
-			this.ACBox.Size = new System.Drawing.Size(136, 20);
-			this.ACBox.TabIndex = 8;
-			// 
-			// ACLbl
-			// 
-			this.ACLbl.AutoSize = true;
-			this.ACLbl.Location = new System.Drawing.Point(12, 165);
-			this.ACLbl.Name = "ACLbl";
-			this.ACLbl.Size = new System.Drawing.Size(24, 13);
-			this.ACLbl.TabIndex = 7;
-			this.ACLbl.Text = "AC:";
-			// 
-			// InfoLbl
-			// 
-			this.InfoLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.InfoLbl.Location = new System.Drawing.Point(12, 9);
-			this.InfoLbl.Name = "InfoLbl";
-			this.InfoLbl.Size = new System.Drawing.Size(254, 33);
-			this.InfoLbl.TabIndex = 0;
-			this.InfoLbl.Text = "These settings will apply to all the creatures, traps and hazards in the campaign" +
-				".";
-			// 
-			// DefenceBox
-			// 
-			this.DefenceBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.DefenceBox.Location = new System.Drawing.Point(130, 189);
-			this.DefenceBox.Minimum = new decimal(new int[] {
+            this.ACBox.Name = "ACBox";
+            this.ACBox.Size = new System.Drawing.Size(136, 20);
+            this.ACBox.TabIndex = 8;
+            // 
+            // ACLbl
+            // 
+            this.ACLbl.AutoSize = true;
+            this.ACLbl.Location = new System.Drawing.Point(12, 185);
+            this.ACLbl.Name = "ACLbl";
+            this.ACLbl.Size = new System.Drawing.Size(24, 13);
+            this.ACLbl.TabIndex = 7;
+            this.ACLbl.Text = "AC:";
+            // 
+            // InfoLbl
+            // 
+            this.InfoLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.InfoLbl.Location = new System.Drawing.Point(12, 9);
+            this.InfoLbl.Name = "InfoLbl";
+            this.InfoLbl.Size = new System.Drawing.Size(254, 33);
+            this.InfoLbl.TabIndex = 0;
+            this.InfoLbl.Text = "These settings will apply to all the creatures, traps and hazards in the campaign" +
+    ".";
+            // 
+            // DefenceBox
+            // 
+            this.DefenceBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.DefenceBox.Location = new System.Drawing.Point(130, 209);
+            this.DefenceBox.Minimum = new decimal(new int[] {
             100,
             0,
             0,
             -2147483648});
-			this.DefenceBox.Name = "DefenceBox";
-			this.DefenceBox.Size = new System.Drawing.Size(136, 20);
-			this.DefenceBox.TabIndex = 10;
-			// 
-			// DefenceLbl
-			// 
-			this.DefenceLbl.AutoSize = true;
-			this.DefenceLbl.Location = new System.Drawing.Point(12, 191);
-			this.DefenceLbl.Name = "DefenceLbl";
-			this.DefenceLbl.Size = new System.Drawing.Size(85, 13);
-			this.DefenceLbl.TabIndex = 9;
-			this.DefenceLbl.Text = "Other Defences:";
-			// 
-			// XPBox
-			// 
-			this.XPBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-						| System.Windows.Forms.AnchorStyles.Right)));
-			this.XPBox.Increment = new decimal(new int[] {
+            this.DefenceBox.Name = "DefenceBox";
+            this.DefenceBox.Size = new System.Drawing.Size(136, 20);
+            this.DefenceBox.TabIndex = 10;
+            // 
+            // DefenceLbl
+            // 
+            this.DefenceLbl.AutoSize = true;
+            this.DefenceLbl.Location = new System.Drawing.Point(12, 211);
+            this.DefenceLbl.Name = "DefenceLbl";
+            this.DefenceLbl.Size = new System.Drawing.Size(85, 13);
+            this.DefenceLbl.TabIndex = 9;
+            this.DefenceLbl.Text = "Other Defences:";
+            // 
+            // XPBox
+            // 
+            this.XPBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.XPBox.Increment = new decimal(new int[] {
             5,
             0,
             0,
             0});
-			this.XPBox.Location = new System.Drawing.Point(130, 79);
-			this.XPBox.Maximum = new decimal(new int[] {
+            this.XPBox.Location = new System.Drawing.Point(130, 79);
+            this.XPBox.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
-			this.XPBox.Name = "XPBox";
-			this.XPBox.Size = new System.Drawing.Size(136, 20);
-			this.XPBox.TabIndex = 4;
-			// 
-			// XPLbl
-			// 
-			this.XPLbl.AutoSize = true;
-			this.XPLbl.Location = new System.Drawing.Point(12, 81);
-			this.XPLbl.Name = "XPLbl";
-			this.XPLbl.Size = new System.Drawing.Size(112, 13);
-			this.XPLbl.TabIndex = 3;
-			this.XPLbl.Text = "Experience Points (%):";
-			// 
-			// CampaignSettingsForm
-			// 
-			this.AcceptButton = this.OKBtn;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.CancelBtn;
-			this.ClientSize = new System.Drawing.Size(278, 266);
-			this.Controls.Add(this.XPBox);
-			this.Controls.Add(this.XPLbl);
-			this.Controls.Add(this.DefenceBox);
-			this.Controls.Add(this.DefenceLbl);
-			this.Controls.Add(this.InfoLbl);
-			this.Controls.Add(this.ACBox);
-			this.Controls.Add(this.ACLbl);
-			this.Controls.Add(this.AttackBox);
-			this.Controls.Add(this.AttackLbl);
-			this.Controls.Add(this.HPBox);
-			this.Controls.Add(this.HPLbl);
-			this.Controls.Add(this.CancelBtn);
-			this.Controls.Add(this.OKBtn);
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "CampaignSettingsForm";
-			this.ShowIcon = false;
-			this.ShowInTaskbar = false;
-			this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Campaign Settings";
-			((System.ComponentModel.ISupportInitialize)(this.HPBox)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.AttackBox)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.ACBox)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.DefenceBox)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.XPBox)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.XPBox.Name = "XPBox";
+            this.XPBox.Size = new System.Drawing.Size(136, 20);
+            this.XPBox.TabIndex = 4;
+            // 
+            // XPLbl
+            // 
+            this.XPLbl.AutoSize = true;
+            this.XPLbl.Location = new System.Drawing.Point(12, 81);
+            this.XPLbl.Name = "XPLbl";
+            this.XPLbl.Size = new System.Drawing.Size(112, 13);
+            this.XPLbl.TabIndex = 3;
+            this.XPLbl.Text = "Experience Points (%):";
+            // 
+            // DamageBox
+            // 
+            this.DamageBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.DamageBox.Increment = new decimal(new int[] {
+            5,
+            0,
+            0,
+            0});
+            this.DamageBox.Location = new System.Drawing.Point(130, 150);
+            this.DamageBox.Maximum = new decimal(new int[] {
+            1000,
+            0,
+            0,
+            0});
+            this.DamageBox.Name = "DamageBox";
+            this.DamageBox.Size = new System.Drawing.Size(136, 20);
+            this.DamageBox.TabIndex = 14;
+            // 
+            // dmgMultLbl
+            // 
+            this.dmgMultLbl.AutoSize = true;
+            this.dmgMultLbl.Location = new System.Drawing.Point(12, 152);
+            this.dmgMultLbl.Name = "dmgMultLbl";
+            this.dmgMultLbl.Size = new System.Drawing.Size(111, 13);
+            this.dmgMultLbl.TabIndex = 13;
+            this.dmgMultLbl.Text = "Damage Multiplier (%):";
+            // 
+            // CampaignSettingsForm
+            // 
+            this.AcceptButton = this.OKBtn;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.CancelBtn;
+            this.ClientSize = new System.Drawing.Size(278, 291);
+            this.Controls.Add(this.DamageBox);
+            this.Controls.Add(this.dmgMultLbl);
+            this.Controls.Add(this.XPBox);
+            this.Controls.Add(this.XPLbl);
+            this.Controls.Add(this.DefenceBox);
+            this.Controls.Add(this.DefenceLbl);
+            this.Controls.Add(this.InfoLbl);
+            this.Controls.Add(this.ACBox);
+            this.Controls.Add(this.ACLbl);
+            this.Controls.Add(this.AttackBox);
+            this.Controls.Add(this.AttackLbl);
+            this.Controls.Add(this.HPBox);
+            this.Controls.Add(this.HPLbl);
+            this.Controls.Add(this.CancelBtn);
+            this.Controls.Add(this.OKBtn);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "CampaignSettingsForm";
+            this.ShowIcon = false;
+            this.ShowInTaskbar = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "Campaign Settings";
+            ((System.ComponentModel.ISupportInitialize)(this.HPBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.AttackBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.ACBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DefenceBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.XPBox)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.DamageBox)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -260,5 +294,7 @@
 		private System.Windows.Forms.Label DefenceLbl;
 		private System.Windows.Forms.NumericUpDown XPBox;
 		private System.Windows.Forms.Label XPLbl;
-	}
+        private System.Windows.Forms.NumericUpDown DamageBox;
+        private System.Windows.Forms.Label dmgMultLbl;
+    }
 }

--- a/Masterplan/UI/CampaignSettingsForm.cs
+++ b/Masterplan/UI/CampaignSettingsForm.cs
@@ -16,6 +16,7 @@ namespace Masterplan.UI
 			HPBox.Value = (int)(fSettings.HP * 100);
 			XPBox.Value = (int)(fSettings.XP * 100);
 			AttackBox.Value = fSettings.AttackBonus;
+			DamageBox.Value = (int)(fSettings.Damage*100);
 			ACBox.Value = fSettings.ACBonus;
 			DefenceBox.Value = fSettings.NADBonus;
 		}
@@ -27,6 +28,7 @@ namespace Masterplan.UI
 			fSettings.HP = (double)HPBox.Value / 100;
 			fSettings.XP = (double)XPBox.Value / 100;
 			fSettings.AttackBonus = (int)AttackBox.Value;
+			fSettings.Damage = (double)DamageBox.Value/100.0;
 			fSettings.ACBonus = (int)ACBox.Value;
 			fSettings.NADBonus = (int)DefenceBox.Value;
 		}

--- a/Masterplan/UI/CampaignSettingsForm.resx
+++ b/Masterplan/UI/CampaignSettingsForm.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>

--- a/Masterplan/UI/CampaignSettingsForm.resx
+++ b/Masterplan/UI/CampaignSettingsForm.resx
@@ -112,9 +112,9 @@
     <value>2.0</value>
   </resheader>
   <resheader name="reader">
-    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
 </root>


### PR DESCRIPTION
I like to make my combat more deadly by adjusting moster damage up (as well as their attack bonus up and the hp and defenses down)
The code change could be smarter at pulling out damage numbers as currently it will try to adjust effects such as shift 2 squares

I can take out the form versioning change if you wish