### PR TITLE
Creature stat fixes

### DIFF
--- a/Masterplan/Tools/Statistics.cs
+++ b/Masterplan/Tools/Statistics.cs
@@ -104,13 +104,6 @@ namespace Masterplan.Tools
 			}
 			else
 			{
-				if ((role != null) && (role is ComplexRole))
-				{
-					ComplexRole cr = role as ComplexRole;
-					if (cr.Type == RoleType.Soldier)
-						return level + 5;
-				}
-
 				return level + 3;
 			}
 		}

--- a/Masterplan/Tools/Statistics.cs
+++ b/Masterplan/Tools/Statistics.cs
@@ -20,11 +20,11 @@ namespace Masterplan.Tools
 				ComplexRole cr = role as ComplexRole;
 				switch (cr.Type)
 				{
-					case RoleType.Soldier:
+					case RoleType.Lurker:
 						score += 4;
 						break;
 					case RoleType.Skirmisher:
-					case RoleType.Brute:
+					case RoleType.Soldier:
 						score += 2;
 						break;
 				}


### PR DESCRIPTION
For the custom creature builder, I've fixed:
- Initiative bonuses, which were tied to the wrong creature roles.
- Attack bonus of soldiers against non-AC defenses, which were equal to AC attacks instead of being 2 points lower.